### PR TITLE
Feat: Introduce `cak-group` Command

### DIFF
--- a/cmd/server/dependency.go
+++ b/cmd/server/dependency.go
@@ -82,6 +82,7 @@ func InitDependencies(ctx context.Context, conf *config.Config) (startup Startup
 		&inject.Object{Value: &repository.ScopeRepository{}},
 		&inject.Object{Value: &repository.UserRepository{}},
 		&inject.Object{Value: &repository.SSHRepository{}},
+		&inject.Object{Value: &repository.CommandGroupRepository{}},
 		&inject.Object{Value: db},
 		&inject.Object{Value: &basePath, Name: "basePath"},
 		&inject.Object{Value: goCache},

--- a/cmd/server/router.go
+++ b/cmd/server/router.go
@@ -35,6 +35,7 @@ func createHandler(ctx context.Context, rootHandler handler.RootHandler) http.Ha
 	router.HandleFunc("/console/verify", rootHandler.Console.Verify).Methods("POST")
 	router.HandleFunc("/console/exec", rootHandler.Console.Exec).Methods("POST")
 	router.HandleFunc("/console/ssh", rootHandler.Console.SSH).Methods("POST")
+	router.HandleFunc("/console/ssh", rootHandler.Console.DeleteSSH).Methods("DELETE")
 
 	// UI
 	ui := router.PathPrefix("/").Subrouter()

--- a/domain/handler/console.go
+++ b/domain/handler/console.go
@@ -122,6 +122,33 @@ func (h ConsoleHandler) SSH(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// DeleteSSH will delete ssh config
+func (h ConsoleHandler) DeleteSSH(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	_, err := h.verifyAuthSign(r)
+	if err != nil {
+		response.Failed(r.Context(), w, http.StatusUnauthorized, err)
+		return
+	}
+
+	// Parse request parameters
+	sshID := r.FormValue("id")
+	if sshID == "" {
+		response.Failed(ctx, w, http.StatusBadRequest, fmt.Errorf("missing id parameter"))
+		return
+	}
+
+	err = h.ConsoleService.DeleteSSHByID(ctx, sshID)
+	if err != nil {
+		response.Failed(ctx, w, http.StatusInternalServerError, err)
+		return
+	}
+
+	response.Success(ctx, w, http.StatusOK, map[string]interface{}{
+		"message": "success",
+	})
+}
+
 func (h ConsoleHandler) Verify(w http.ResponseWriter, r *http.Request) {
 	_, err := h.verifyAuthSign(r)
 	if err != nil {

--- a/domain/model/command_group.go
+++ b/domain/model/command_group.go
@@ -1,0 +1,10 @@
+package model
+
+import uuid "github.com/satori/go.uuid"
+
+type CommandGroup struct {
+	GroupName string    `db:"groupName" json:"groupName"`
+	CommandID uuid.UUID `db:"commandID" json:"commandID"`
+	TeamID    uuid.UUID `db:"teamID" json:"teamID"`
+	GivenID   string    `db:"givenID" json:"givenID"`
+}

--- a/domain/repository/command_group.go
+++ b/domain/repository/command_group.go
@@ -1,0 +1,77 @@
+package repository
+
+import (
+	"cakcuk/domain/model"
+	errorLib "cakcuk/utils/errors"
+	"cakcuk/utils/logging"
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// CommandGroupInterface defines the interface for CommandGroup-related database operations
+type CommandGroupInterface interface {
+	InsertCommandGroup(ctx context.Context, input model.CommandGroup) error
+	GetCommandGroupByName(ctx context.Context, groupName string) (*model.CommandGroup, error)
+	GetCommandGroupsByTeamID(ctx context.Context, teamID string) ([]model.CommandGroup, error)
+	DeleteCommandGroupByName(ctx context.Context, name string) error
+}
+
+// CommandGroupRepository is responsible for handling CommandGroup and CommandCommandGroup related database operations
+type CommandGroupRepository struct {
+	DB *sqlx.DB `inject:""`
+}
+
+// InsertCommandGroup inserts an CommandGroup record into the database
+func (r *CommandGroupRepository) InsertCommandGroup(ctx context.Context, input model.CommandGroup) error {
+	q := `INSERT INTO CommandGroup (groupName, commandID, teamID, givenID)
+	VALUES (?, ?, ?, ?)`
+	args := []interface{}{input.GroupName, input.CommandID, input.TeamID, input.GivenID}
+	_, err := r.DB.ExecContext(ctx, q, args...)
+	if err != nil {
+		err = errorLib.TranslateSQLError(err)
+		if err != errorLib.ErrorNotExist {
+			logging.Logger(ctx).Info(errorLib.FormatQueryError(q, args...))
+			logging.Logger(ctx).Error(err)
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *CommandGroupRepository) GetCommandGroupByName(ctx context.Context, groupName string) (*model.CommandGroup, error) {
+	var out model.CommandGroup
+	err := r.DB.Unsafe().GetContext(ctx, &out, `
+	    SELECT * FROM CommandGroup WHERE groupName = ?
+	`, groupName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get CommandGroup: %v", err)
+	}
+	return &out, nil
+}
+
+func (r *CommandGroupRepository) GetCommandGroupsByTeamID(ctx context.Context, teamID string) ([]model.CommandGroup, error) {
+	var out []model.CommandGroup
+	err := r.DB.Unsafe().SelectContext(ctx, &out, `
+	    SELECT * FROM CommandGroup WHERE teamID = ?
+	`, teamID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("unable to get CommandGroups: %v", err)
+	}
+	return out, nil
+}
+
+func (r *CommandGroupRepository) DeleteCommandGroupByName(ctx context.Context, name string) error {
+	_, err := r.DB.Unsafe().ExecContext(ctx, `
+	    DELETE FROM CommandGroup WHERE groupName = ?
+	`, name)
+	if err != nil {
+		return fmt.Errorf("unable to delete CommandGroup: %v", err)
+	}
+	return nil
+}

--- a/domain/repository/ssh.go
+++ b/domain/repository/ssh.go
@@ -17,6 +17,7 @@ type SSHInterface interface {
 	InsertSSH(ctx context.Context, ssh model.SSH) (uuid.UUID, error)
 	GetSSHbyCreatedByAndTeamID(ctx context.Context, createdBy uuid.UUID, teamID uuid.UUID) ([]model.SSH, error)
 	GetSSHbyID(ctx context.Context, sshID uuid.UUID) (*model.SSH, error)
+	DeleteSSHbyID(ctx context.Context, sshID uuid.UUID) error
 	InsertCommandSSH(ctx context.Context, commandSSH model.CommandSSH) error
 }
 
@@ -64,6 +65,16 @@ func (r *SSHRepository) GetSSHbyID(ctx context.Context, sshID uuid.UUID) (*model
 		return nil, fmt.Errorf("unable to get SSH: %v", err)
 	}
 	return &ssh, nil
+}
+
+func (r *SSHRepository) DeleteSSHbyID(ctx context.Context, sshID uuid.UUID) error {
+	_, err := r.DB.Unsafe().ExecContext(ctx, `
+	    DELETE FROM SSH WHERE id = ?
+	`, sshID)
+	if err != nil {
+		return fmt.Errorf("unable to delete SSH: %v", err)
+	}
+	return nil
 }
 
 // InsertCommandSSH inserts a CommandSSH record into the database

--- a/domain/service/console.go
+++ b/domain/service/console.go
@@ -114,6 +114,14 @@ func (s *ConsoleService) GetSSHByID(ctx context.Context, sshID string) (*model.S
 	return ssh, nil
 }
 
+func (s *ConsoleService) DeleteSSHByID(ctx context.Context, sshID string) error {
+	err := s.SSHRepository.DeleteSSHbyID(ctx, uuid.FromStringOrNil(sshID))
+	if err != nil {
+		return fmt.Errorf("unable to delete SSH by ID: %v", err)
+	}
+	return nil
+}
+
 func (s *ConsoleService) encryptSSH(value, salt string) (string, error) {
 	tobeEncrypted := salt + value + salt
 	encryptSSHKey, err := stringLib.Encrypt(tobeEncrypted, s.Config.EncryptionPassword)

--- a/domain/service/params.go
+++ b/domain/service/params.go
@@ -1,0 +1,15 @@
+package service
+
+import (
+	"cakcuk/domain/model"
+
+	uuid "github.com/satori/go.uuid"
+)
+
+type InputCakGroup struct {
+	cmd        model.CommandModel
+	teamID     uuid.UUID
+	botName    string
+	executedBy string
+	scopes     model.ScopesModel
+}

--- a/migration/001_init_tables.sql
+++ b/migration/001_init_tables.sql
@@ -20,6 +20,14 @@ CREATE TABLE `CommandSSH` (
   PRIMARY KEY (`sshID`, `commandID`)
 );
 
+CREATE TABLE `CommandGroup` (
+  `groupName` char(100) NOT NULL,
+  `teamID` char(36) NOT NULL,
+  `commandID` char(36) NOT NULL,
+  `givenID` char(100) NULL,
+  PRIMARY KEY (`groupName`, `commandID`)
+);
+
 CREATE TABLE `Command` (
   `id` char(36) NOT NULL,
   `teamID` char(36) DEFAULT NULL,
@@ -27,6 +35,7 @@ CREATE TABLE `Command` (
   `description` text,
   `example` text,
   `completeDescription` text,
+  `groupName` char(100) NULL,
   `created`  timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `createdBy` char(36) NOT NULL,
   PRIMARY KEY (`id`)

--- a/utils/errors/const.go
+++ b/utils/errors/const.go
@@ -9,6 +9,7 @@ const (
 	ExtractCommandInvalid   = "ExtractCommandInvalid"
 	HelpCommandInvalid      = "HelpCommandInvalid"
 	CakCommandInvalid       = "CakCommandInvalid"
+	CakGroupCommandInvalid  = "CakGroupCommandInvalid"
 	CukCommandInvalid       = "CukCommandInvalid"
 	DelCommandInvalid       = "DelCommandInvalid"
 	ScopeCommandInvalid     = "ScopeCommandInvalid"
@@ -34,6 +35,7 @@ var (
 	ErrorScope             = WithMessage(ScopeCommandInvalid, "Failed to execute scope.")
 	ErrorSuperUser         = WithMessage(SuperUserCommandInvalid, "Failed to execute superuser.")
 	ErrorCustomCommand     = WithMessage(CustomCommandInvalid, "Failed to process command.")
+	ErrorCakGroup          = WithMessage(CakGroupCommandInvalid, "Failed to process command.")
 	ErrorPersistenceCheck  = WithMessage(PersistenceFailed, "Failed to ping persinstences.")
 	ErrorCommandNotAllowed = WithMessage(CommandNotAllowed, "Command is not allowed.")
 	ErrorTableAlreadyExist = Error{Code: TableAlreadyExist}


### PR DESCRIPTION
**Summary**

- `cak-group` is a command to create a custom command which contains multiple HTTP requests whereas `cak` only contains a single command.

<img width="1297" alt="Screenshot 2023-09-07 at 10 59 14 PM" src="https://github.com/isdzulqor/cakcuk/assets/12388558/3ce9b16f-673c-4b19-819a-89bd8c7d0283">
<img width="1283" alt="Screenshot 2023-09-07 at 10 59 21 PM" src="https://github.com/isdzulqor/cakcuk/assets/12388558/7c96da3f-8991-4e73-8fd4-8a180e3db2b2">
<img width="1304" alt="Screenshot 2023-09-07 at 11 00 13 PM" src="https://github.com/isdzulqor/cakcuk/assets/12388558/cafe0518-0dd5-44e0-a1ae-76c00d6717a4">
