### PR TITLE
Feat: Add `allowed channels` Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ When you use Slack Event API, you also need to set events those you subscribe to
   * [app_home_opened](https://api.slack.com/events/app_home_opened)
   * [app_mention](https://api.slack.com/events/app_mention)
   * [message.im](https://api.slack.com/events/message.im)
+  * [member_joined_channel](https://api.slack.com/events/member_joined_channel)
 
 
 #### Needed Slack Scopes for your Cakcuk
@@ -93,6 +94,13 @@ When you use Slack Event API, you also need to set events those you subscribe to
   * im:history
   * team:read
   * users:read
+  * channels:read
+  * groups:read
+  * mpim:read
+  * channels:manage 
+  * groups:write 
+  * im:write 
+  * mpim:write
 
 #### A Bit Differences between Slack Event API & Slack RTM API
   * `Slack RTM API` doesn't need to expose a public endpoint. Thus it's easier to integrate with your private cluster if you have. `Slack Event API` needs to has a public endpoint and register it to Slack to be challenged.
@@ -208,6 +216,13 @@ The following steps are the straightforward steps to create Slack App with Slack
 	* im:history
 	* team:read
 	* users:read
+	* channels:read
+  	* groups:read
+  	* mpim:read
+	* channels:manage 
+	* groups:write 
+	* im:write 
+	* mpim:write
 
 	<img width="749" alt="Screenshot 2023-09-05 at 3 37 26 PM" src="https://github.com/isdzulqor/cakcuk/assets/12388558/151765f5-1e48-4b48-a641-95f986dc43de">
 
@@ -225,6 +240,7 @@ The following steps are the straightforward steps to create Slack App with Slack
 	* app_home_opened
 	* app_mention
 	* message.im
+	* member_joined_channel
 
 	<img width="704" alt="Screenshot 2023-09-05 at 3 56 28 PM" src="https://github.com/isdzulqor/cakcuk/assets/12388558/a4c8b44c-8c95-41de-bd5b-827d2be2cf40">
 

--- a/domain/service/command.go
+++ b/domain/service/command.go
@@ -39,7 +39,8 @@ func (s *CommandService) Prepare(ctx context.Context, textInput, userReferenceID
 	botName, source string, channelRef string, teamInfo *model.TeamModel) (out model.CommandResponseModel, err error) {
 	out.Source = source
 	if stringLib.IsEmpty(textInput) {
-		err = fmt.Errorf(model.SlackStartedMessage)
+		slackStartedMsg := strings.ReplaceAll(model.SlackStartedMessage, "https://cakcuk.io/play", s.Config.Site.PlayPage)
+		err = fmt.Errorf(slackStartedMsg)
 		return
 	}
 	if teamInfo == nil {

--- a/external/params.go
+++ b/external/params.go
@@ -7,3 +7,8 @@ type InputPostMessage struct {
 	Channel  string
 	Text     string
 }
+
+type InputLeaveChannel struct {
+	Token   *string
+	Channel string
+}

--- a/external/slack.go
+++ b/external/slack.go
@@ -283,6 +283,34 @@ func (s SlackClientCustom) PostMessage(ctx context.Context, input InputPostMessa
 	return
 }
 
+func (s SlackClientCustom) LeaveChannel(ctx context.Context, input InputLeaveChannel) (err error) {
+	var slackBaseResponse SlackBaseResponse
+
+	slackURL := s.url + "/api/conversations.leave"
+	params := url.Values{
+		"channel": {input.Channel},
+	}
+
+	headers := map[string]string{
+		"Authorization": s.readToken(input.Token),
+	}
+
+	resp, _, err := request.Request(ctx, "POST", slackURL, params, headers, nil, false)
+	if err != nil {
+		err = errorLib.ErrorSlackClientInvalid.AppendMessage(err.Error())
+		return
+	}
+	if err = json.Unmarshal(resp, &slackBaseResponse); err != nil {
+		err = errorLib.ErrorSlackClientInvalid.AppendMessage(err.Error())
+		return
+	}
+	if !slackBaseResponse.Ok && slackBaseResponse.Error != nil {
+		err = errorLib.ErrorSlackClientInvalid.AppendMessage(*slackBaseResponse.Error)
+		return
+	}
+	return
+}
+
 func (s SlackClientCustom) GetTeamInfo(ctx context.Context, token *string) (out SlackTeamCustom, err error) {
 	var response struct {
 		SlackBaseResponse


### PR DESCRIPTION
**Summary**

- Allowed Channels will limit Cakcuk to be accessed from the certain channel only
- Allowed Channels is active only the env of `ALLOWED_CHANNELS` is not empty and contains the allowed Slack Channel IDs
- If Cakcuk is invited to the unallowed channel it will post a message and leave the channel automatically as the following sample
<img width="743" alt="image" src="https://github.com/isdzulqor/cakcuk/assets/12388558/acc78af0-9ee7-43db-a0af-7d85c76c6fdf">

