### PR TITLE
Feat: Simplify Help Command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # Run integration test
-# need docker-compose and docker installed
+# need docker compose and docker installed
 integration-test:
-	docker-compose -f docker-compose.test.yaml up -d
+	docker compose -f docker-compose.test.yaml up -d
 	sleep 10
 	go test -v ./...
-	docker-compose -f docker-compose.test.yaml down
+	docker compose -f docker-compose.test.yaml down
 
 # Run playground-ui on dev mode using npm
 # need nodejs and npm installed
@@ -52,7 +52,7 @@ run:
 
 	SLACK_TOKEN=${SLACK_TOKEN} \
 		SLACK_VERIFICATION_TOKEN=${SLACK_VERIFICATION_TOKEN} \
-		docker-compose -f docker-compose.yaml up --build --remove-orphans
+		docker compose -f docker-compose.yaml up --build --remove-orphans
 
 
 # Read the contents of `loader.yaml` into a variable
@@ -72,4 +72,4 @@ run-with-sqlite:
 		SLACK_VERIFICATION_TOKEN=${SLACK_VERIFICATION_TOKEN} \
 		LOADER="${LOADER}" \
 		ALLOWED_CHANNELS=${ALLOWED_CHANNELS} \
-		docker-compose -f docker-compose.sqlite.yaml up --build --remove-orphans
+		docker compose -f docker-compose.sqlite.yaml up --build --remove-orphans

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "2.3"
-
 services:
   cakcuk_app:
     image: cosmtrek/air
@@ -27,7 +25,7 @@ services:
       - SITE_LANDING_PAGE=http://localhost:8080
 
   cakcuk_mysql:
-    image: mysql:8
+    image: mysql:8.0
     ports: 
       - 33070:3306
     healthcheck:


### PR DESCRIPTION
**Summary**

Previously, running "help @cakcuk" would display all detailed commands, which could become noisy when the list was large.
This PR changes the behavior so that "help @cakcuk" now shows a simple summary by default, making the output cleaner.
It also adds the note:
```
Get the detailed help for a specific command by running help -c=<command_name> @testappcakcuk
to guide users who want to view full command details.
```

**Result Example**
<img width="1023" height="325" alt="image" src="https://github.com/user-attachments/assets/33e7c65f-6eda-44aa-bd35-1ea5dcb88f9e" />

**Additionals**
- Use "docker compose" instead of deprecated "docker-compose" in Makefile